### PR TITLE
add checkpointing and support multi-value  GT fields

### DIFF
--- a/VCFdb.R
+++ b/VCFdb.R
@@ -15,7 +15,7 @@ the 'pipeline/' directory.
 Required Arguments:
 --prefix [character] 
     Will be the name of the database and other 
-    files produced bt the pipeline. 
+    files produced by the pipeline. 
 --vcf [character]
     The name of the input VCF. Should not have
     multialleleic sites. If VEP annotatios are
@@ -46,8 +46,15 @@ Optional Arguments:
     what is available on your machine. 
     Anecdotal testing finds the optimal number
     to be between 2 and 10, depending on many
-    factors.
-    Requires the `furrr` package.")
+    factors. Requires the `furrr` package.
+--include-multivalue-gt 
+    Include GT fields which have multiple values
+    for each sample. Can be slow for VCFs with
+    many samples, due to the way such fields are
+    handeld by VariantAnnotation::readVcf(). If 
+    preserving these fields is important, it may
+    be worth first separating them in the input 
+    VCF.")
     stop()
   } else if(args[1] == '--mode'){
     if(args[2] == 'file'){
@@ -67,6 +74,10 @@ Optional Arguments:
   } else if(args[1] == "--chunk-size"){
     chunk_size <- args[2]
     args <- args[-1:-2]
+  } else if(args[1] == "--include-multivalue-gt"){
+    multi_gt <- TRUE
+    args <- args[-1]
+    message("Including GENO Fields with multiple values (may be slow for many samples)")
   } else if(args[1] == "--threads"){
     run_parallel <- TRUE
     threads <- args[2]

--- a/pipeline/01-generate-variant-ranges-index.R
+++ b/pipeline/01-generate-variant-ranges-index.R
@@ -27,8 +27,8 @@ if(!exists("vcf_name")){
   stop("A vcf must be passed with the `--vcf` argument")
 }
 
-require(VariantAnnotation)
-require(tidyverse)
+suppressPackageStartupMessages(require(VariantAnnotation))
+suppressPackageStartupMessages(require(tidyverse))
 
 #### Generate Chunks of Variants ####
 message('######\nLOADING RANGES\n######')

--- a/pipeline/01-generate-variant-ranges-index.R
+++ b/pipeline/01-generate-variant-ranges-index.R
@@ -30,6 +30,7 @@ if(!exists("vcf_name")){
 suppressPackageStartupMessages(require(VariantAnnotation))
 suppressPackageStartupMessages(require(tidyverse))
 
+if(!file.exists(paste0(prefix, ".progress.RData"))){
 #### Generate Chunks of Variants ####
 message('######\nLOADING RANGES\n######')
 
@@ -87,3 +88,4 @@ gc()
 message('######\nDONE IDENTIFYING CHUNKS\nRANGES ARE WRITTEN TO:\n', 
         paste0(prefix, "-chunk-ranges.rds"),
         '\n######')
+}

--- a/pipeline/02-build-db.R
+++ b/pipeline/02-build-db.R
@@ -3,6 +3,7 @@ args = commandArgs(trailingOnly=TRUE)
 
 ## defaults ##
 run_parallel <- FALSE
+multi_gt <- FALSE
 
 while(length(args > 0) ){
   if(args[1] == '--mode'){
@@ -26,6 +27,10 @@ while(length(args > 0) ){
     ranges_name <- args[2]
     args <- args[-1:-2]
     message("Input variant chunk ranges: ", ranges_name)
+  } else if(args[1] == "--include-multivalue-gt"){
+    multi_gt <- TRUE
+    args <- args[-1]
+    message("Including GENO Fields with multiple values (may be slow for many samples)")
   } else if(args[1] == "--threads"){
     run_parallel <- TRUE
     threads <- args[2]

--- a/pipeline/02-build-db.R
+++ b/pipeline/02-build-db.R
@@ -276,6 +276,7 @@ for(i in 1:p){
       gather(sample, !!.geno_col, -variant_id, -group)
     
     for(.geno_col in geno_col_names[-1]){
+      message(.geno_col) ## debug
       geno_col <- enquo(.geno_col)
       geno.vcf <- geno.vcf %>%
         bind_cols(

--- a/pipeline/02-build-db.R
+++ b/pipeline/02-build-db.R
@@ -129,7 +129,7 @@ keep_geno_col <- sapply(geno_col_names, function(col_name){
   
   col_class <- type(geno(tmp.vcf)[[col_name]])
   
-  if(!(col_class %in% c("character", "integer", "numeric"))){
+  if(!(col_class %in% c("character", "integer", "numeric", "double"))){
     warning("geno column '", col_name, "'is of upsupported type '", col_class, ". It will be skipped.")
     return(FALSE)
   }
@@ -248,8 +248,11 @@ for(i in 1:p){
     
   } else{
     info.vcf <- tibble(variant_id = var_ind) %>%
-      bind_cols(.vcf@rowRanges %>% as_tibble () %>% select(seqnames, start, end) %>% rename('chr' = seqnames)) %>%
-      bind_cols(.vcf@fixed %>% as_tibble()) %>%
+      bind_cols(.vcf@rowRanges %>% 
+                  as_tibble() %>% 
+                  select(seqnames, start, end) %>% 
+                  rename('chr' = seqnames)) %>%
+      bind_cols(.vcf@fixed %>% as_tibble(), ) %>%
       bind_cols(.vcf@info %>% as_tibble()) 
   }
   

--- a/pipeline/02-build-db.R
+++ b/pipeline/02-build-db.R
@@ -518,11 +518,15 @@ for(i in seq(chunk_start,p)){
   
   chunk_start <- i
   index_start <- last(var_ind)
-  save(index_start, chunk_start, csq_exists, csq_cols, exonic_impacts, geno_col_names, gt2snp, header, keep_geno_col, ranges_name, vcf_header, vcf_name, 
+  save(list = c(
+    'index_start', 'chunk_start', 'exonic_impacts', 'geno_col_names', 'gt2snp', 
+    'header', 'keep_geno_col', 'ranges_name', 'vcf_header', 'vcf_name',
+    if(csq_exists){c('csq_exists', 'csq_cols')}
+  ),
        file = paste0(prefix, ".progress.RData"))
 }
 
-## end loop
+#### end loop ####
 message("######\nDone inserting variants\n#####")
 date()
 closeAllConnections()

--- a/pipeline/02-build-db.R
+++ b/pipeline/02-build-db.R
@@ -127,7 +127,7 @@ keep_geno_col <- sapply(geno_col_names, function(col_name){
     return(FALSE)
     }
   
-  col_class <- class(geno(tmp.vcf)[[col_name]][1,1])
+  col_class <- type(geno(tmp.vcf)[[col_name]])
   
   if(!(col_class %in% c("character", "integer", "numeric"))){
     warning("geno column '", col_name, "'is of upsupported type '", col_class, ". It will be skipped.")

--- a/pipeline/02-build-db.R
+++ b/pipeline/02-build-db.R
@@ -4,6 +4,8 @@ args = commandArgs(trailingOnly=TRUE)
 ## defaults ##
 run_parallel <- FALSE
 multi_gt <- FALSE
+end_provided <- FALSE
+debug_mode <- FALSE
 
 while(length(args > 0) ){
   if(args[1] == '--mode'){
@@ -12,8 +14,8 @@ while(length(args > 0) ){
     } else if(args[2] == 'table'){
       file_mode = FALSE
     } else {
-        stop("`--mode` argument requires one of two options: 'file' or 'table'")
-      }
+      stop("`--mode` argument requires one of two options: 'file' or 'table'")
+    }
     args <- args[-1:-2]
   } else if(args[1] == '--prefix'){
     prefix <- args[2]
@@ -27,10 +29,19 @@ while(length(args > 0) ){
     ranges_name <- args[2]
     args <- args[-1:-2]
     message("Input variant chunk ranges: ", ranges_name)
+  } else if(args[1] == "--end-chunk"){
+    end_provided <- TRUE
+    p <- as.integer(args[2])
+    args <- args[-1:-2]
+    message("Input variant chunk ranges: ", ranges_name)
   } else if(args[1] == "--include-multivalue-gt"){
     multi_gt <- TRUE
     args <- args[-1]
     message("Including GENO Fields with multiple values (may be slow for many samples)")
+  } else if(args[1] == "--debug"){
+    debug_mode <- TRUE
+    args <- args[-1]
+    message("Debug mode enabled, producing verbose output")
   } else if(args[1] == "--threads"){
     run_parallel <- TRUE
     threads <- args[2]
@@ -67,127 +78,142 @@ if(!exists('file_mode')){
   message("Building a database where genotypes are saved to a table (variant_geno)")
 }
 
-require(VariantAnnotation)
-require(dbplyr)
-require(tidyverse)
-require(magrittr)
-require(progress)
-require(RSQLite)
+suppressPackageStartupMessages(require(VariantAnnotation))
+suppressPackageStartupMessages(require(tidyverse))
+suppressPackageStartupMessages(require(dbplyr))
+suppressPackageStartupMessages(require(magrittr))
+suppressPackageStartupMessages(require(progress))
+suppressPackageStartupMessages(require(RSQLite))
 
-#### A function to convert genotypes to dosage ####
-gt2snp <- function(x){
-  case_when(
-    str_detect(x, "0\\/\\.|\\.\\/0|0\\/0|0\\|0|^0$")  ~ 0, 
-    str_detect(x, c("0\\/1|1\\/0|0\\|1|1\\|0|\\.\\/1|1\\/\\.|\\.\\|1|1\\|\\.|^1$"))  ~ 1, 
-    str_detect(x,  c("1\\/1|1\\|1")) ~ 2, 
-    TRUE ~ as.numeric(NA)
-  )
-}
 
 if(!exists('chunk_ranges')){
   chunk_ranges <- read_rds(ranges_name)
 }
 
 db_name <- paste0(prefix, ".db")
-#### Insert VCF header information ####
-message('######\nPARSING VCF HEADER\n######')
 
-vcf_header <- scanVcfHeader(vcf_name)
-
-header <- vcf_header@header
-names(header)
-
-lapply(names(header), function(name){
-  X <- header[[name]]
+#### If a progress file is detected, resume from it ####
+if(!file.exists(paste0(prefix, ".progress.RData"))){
+  
+  #### A function to convert genotypes to dosage 
+  gt2snp <- function(x){
+    case_when(
+      str_detect(x, "0\\/\\.|\\.\\/0|0\\/0|0\\|0|^0$")  ~ 0, 
+      str_detect(x, c("0\\/1|1\\/0|0\\|1|1\\|0|\\.\\/1|1\\/\\.|\\.\\|1|1\\|\\.|^1$"))  ~ 1, 
+      str_detect(x,  c("1\\/1|1\\|1")) ~ 2, 
+      TRUE ~ as.numeric(NA)
+    )
+  }
+  
+  #### Insert VCF header information ####
+  message('######\nPARSING VCF HEADER\n######')
+  
+  vcf_header <- scanVcfHeader(vcf_name)
+  
+  header <- vcf_header@header
+  names(header)
+  
+  lapply(names(header), function(name){
+    X <- header[[name]]
+    con <- dbConnect(SQLite(), db_name)
+    DBI::dbWriteTable(
+      conn = con,
+      name = name,
+      value = as_tibble(X, rownames = 'name'), 
+      append = TRUE)
+    DBI::dbDisconnect(con)
+  })
+  
+  ## add samples ##
   con <- dbConnect(SQLite(), db_name)
-  db_insert_into(con = con, 
-                 table = name, 
-                 as_tibble(X, rownames = 'name'))
-  dbDisconnect(con)
-})
-
-## add samples ##
-con <- dbConnect(SQLite(), db_name)
-db_insert_into(con = con, 
-               table = 'samples', 
-               enframe(vcf_header@samples))
-dbDisconnect(con)
-
-#### Check that the geno fields exists ####
-message('######\nCHECKING GENOTYPE FIELDS\n')
-tmp.vcf <- readVcf(vcf_name, param = chunk_ranges[1])
-
-geno_col_names <- geno(tmp.vcf) %>% names()
-
-## Check to make sure the geno fields declared in the header are actually on the data
-## Also check that they are of a supported type (SQLite can't handle list columns)
-keep_geno_col <- sapply(geno_col_names, function(col_name){
-  all_missing <- geno(tmp.vcf)[[col_name]] %>%
-    unlist() %>%
-    is.na() %>%
-    all()
+  DBI::dbWriteTable(
+    conn = con,
+    name = 'samples',
+    value = enframe(vcf_header@samples), 
+    append = TRUE)
+  DBI::dbDisconnect(con)
   
-  if (all_missing){
-    warning("geno column '", col_name, "' appears to be missing. It will be skipped.")
-    return(FALSE)
+  #### Check that the geno fields exists ####
+  message('######\nCHECKING GENOTYPE FIELDS\n')
+  tmp.vcf <- readVcf(vcf_name, param = chunk_ranges[1])
+  
+  geno_col_names <- geno(tmp.vcf) %>% names()
+  
+  ## Check to make sure the geno fields declared in the header are actually on the data
+  ## Also check that they are of a supported type (SQLite can't handle list columns)
+  keep_geno_col <- sapply(geno_col_names, function(col_name){
+    all_missing <- geno(tmp.vcf)[[col_name]] %>%
+      unlist() %>%
+      is.na() %>%
+      all()
+    
+    if (all_missing){
+      warning("geno column '", col_name, "' appears to be missing. It will be skipped.")
+      return(FALSE)
+    }
+    
+    col_class <- class(geno(tmp.vcf)[[col_name]])
+    col_type <- type(geno(tmp.vcf)[[col_name]])
+    
+    
+    if(col_class == "array" & multi_gt){
+      message("geno column '", col_name, "' has multiple values per variant (", dim(geno(tmp.vcf)[[col_name]])[3], "). The package `reshape2` is required to parse.")
+      suppressPackageStartupMessages(require(reshape2))
+    } else if(col_class == "array" & !multi_gt){
+      message("geno column '", col_name, "' has multiple values per variant and will be skipped.")
+      return(FALSE)
+    }
+    
+    if(!(col_type %in% c("character", "integer", "numeric", "double"))){
+      warning("geno column '", col_name, "'is of upsupported type '", col_type, ". It will be skipped.")
+      return(FALSE)
+    }
+    
+    return(TRUE)
+  })
+  
+  geno_col_names <- geno_col_names[keep_geno_col]
+  
+  message("######\n")
+  
+  
+  #### Check to see if CSQ exists ####
+  if(class(tmp.vcf@info$CSQ)!="NULL"){
+    csq_exists = TRUE
+    csq_cols <- vcf_header@header$INFO$Description[rownames(vcf_header@header$INFO) == 'CSQ'] %>%
+      tolower() %>% str_replace_all(" |:|\\.", "_")
+  } else{
+    csq_exists = FALSE
+    message("######\nNo VEP annotations detected.\n######")
   }
+  ## These are the impacts flagged as 'exonic' from VEP
+  exonic_impacts = c("stop_gained",
+                     "exon_variant",
+                     "stop_lost",
+                     "frameshift_variant",
+                     "initiator_codon_variant",
+                     "inframe_deletion",
+                     "inframe_insertion",
+                     "missense_variant",
+                     "protein_altering_variant",
+                     "incomplete_terminal_codon_variant",
+                     "stop_retained_variant",
+                     "5_prime_UTR_premature_start_codon_variant",
+                     "synonymous_variant",
+                     "coding_sequence_variant",
+                     "5_prime_UTR_variant",
+                     "3_prime_UTR_variant",
+                     "transcript_ablation",
+                     "transcript_amplification",
+                     "feature_elongation",
+                     "feature_truncation")
+  rm(tmp.vcf)
   
-  col_class <- class(geno(tmp.vcf)[[col_name]])
-  col_type <- type(geno(tmp.vcf)[[col_name]])
-  
-  
-  if(col_class == "array" & multi_gt){
-    message("geno column '", col_name, "' has multiple values per variant (", dim(geno(tmp.vcf)[[col_name]])[3], "). The package `reshape2` is required to parse.")
-    suppressPackageStartupMessages(require(reshape2))
-  } else if(col_class == "array" & !multi_gt){
-    message("geno column '", col_name, "' has multiple values per variant and will be skipped.")
-    return(FALSE)
-  }
-  
-  if(!(col_type %in% c("character", "integer", "numeric", "double"))){
-    warning("geno column '", col_name, "'is of upsupported type '", col_type, ". It will be skipped.")
-    return(FALSE)
-  }
-  
-  return(TRUE)
-})
-
-geno_col_names <- geno_col_names[keep_geno_col]
-
-message("######\n")
-
-
-#### Check to see if CSQ exists ####
-if(class(tmp.vcf@info$CSQ)!="NULL"){
-  csq_exists = TRUE
-  csq_cols <- vcf_header@header$INFO$Description[rownames(vcf_header@header$INFO) == 'CSQ'] %>%
-    tolower() %>% str_replace_all(" |:|\\.", "_")
-} else{
-  csq_exists = FALSE
-  message("######\nNo VEP annotations detected.\n######")
+  index_start <- 0
+  chunk_start <- 0
+} else {
+  load(paste0(prefix, ".progress.RData"))
 }
-## These are the impacts flagged as 'exonic' from VEP
-exonic_impacts = c("stop_gained",
-                   "exon_variant",
-                   "stop_lost",
-                   "frameshift_variant",
-                   "initiator_codon_variant",
-                   "inframe_deletion",
-                   "inframe_insertion",
-                   "missense_variant",
-                   "protein_altering_variant",
-                   "incomplete_terminal_codon_variant",
-                   "stop_retained_variant",
-                   "5_prime_UTR_premature_start_codon_variant",
-                   "synonymous_variant",
-                   "coding_sequence_variant",
-                   "5_prime_UTR_variant",
-                   "3_prime_UTR_variant",
-                   "transcript_ablation",
-                   "transcript_amplification",
-                   "feature_elongation",
-                   "feature_truncation")
-rm(tmp.vcf)
 
 if(run_parallel){
   require(furrr)
@@ -199,26 +225,43 @@ if(run_parallel){
 #### Build Tables ####
 message("######\nSTARTING TO BUILD DATABASE\n######")
 date()
-p <- length(chunk_ranges)
+
+if(!end_provided){
+  p <- length(chunk_ranges)
+}
+
+pb_total <- p - chunk_start
+
 options(progress_enabled = TRUE)
-pb <- progress_bar$new(total = p, 
+pb <- progress_bar$new(total = pb_total, 
                        clear = FALSE, 
                        force = TRUE,
-                       format = ":current/:total chunks completed in :elapsed; eta: :eta"
-                       )
-index_start <- 0
-for(i in 1:p){
+                       format = "Starting chunk :current/:total after :elapsed; eta: :eta"
+)
+
+chunk_start <- chunk_start + 1
+if(p < chunk_start){
+  stop("End chunk must be after starting chunk!")
+}
+
+for(i in seq(chunk_start,p)){
   pb$tick()
   
   current_ranges <- chunk_ranges[i]
   
   ## set up looping variables
+  if(debug_mode){start <- Sys.time()}
   .vcf <- readVcf(vcf_name, param = current_ranges)
   
   ## generate indicies for our current variants
   var_ind <- (index_start+1):(index_start + length(.vcf))
   
-  index_start <- last(var_ind)
+  if(debug_mode){
+    end <- Sys.time() 
+    message("Done Reading Chunk from VCF:") 
+    print(end - start)
+    start <- end
+  }
   
   ## VEP CSQ goes in the variant_impact table
   if(csq_exists){
@@ -247,18 +290,38 @@ for(i in 1:p){
     
     csq.vcf <- csq.vcf %>%
       {if('clinvar_sig' %in% colnames(clinvar.vcf)){
-        left_join(., clinvar.vcf %>% select(variant_id, clinvar_sig) %>% unnest(clinvar_sig)) 
+        left_join(., clinvar.vcf %>% 
+                    select(variant_id, clinvar_sig) %>% 
+                    unnest(clinvar_sig), 
+                  by = "variant_id") 
       } else {.}} %>%
       {if('clinvar_disease_name' %in% colnames(clinvar.vcf)){
-        left_join(., clinvar.vcf %>% select(variant_id, clinvar_disease_name) %>% unnest(clinvar_disease_name)) 
+        left_join(., clinvar.vcf %>% 
+                    select(variant_id, clinvar_disease_name) %>% 
+                    unnest(clinvar_disease_name), 
+                  by = "variant_id") 
       } else {.}} %>%
       select(variant_id, everything())
-  
-  ## other info goes into into the variant_info table
+    
+    if(debug_mode){
+      end <- Sys.time() 
+      message("Done Parsing Variant Impact:")
+      print(end - start)
+      start <- end
+    }
+    
+    ## other info goes into into the variant_info table
     info.vcf <- tibble(variant_id = var_ind) %>%
       bind_cols(.vcf@rowRanges %>% as_tibble () %>% select(seqnames, start, end) %>% rename('chr' = seqnames)) %>%
       bind_cols(.vcf@fixed %>% as_tibble()) %>%
       bind_cols(.vcf@info %>% as_tibble() %>% select(-any_of(c('CSQ', 'clinvar_sig', 'clinvar_disease_name'))))
+    
+    if(debug_mode){
+      end <- Sys.time()
+      message("Done Parsing Variant Info:")
+      print(end - start)
+      start <- end
+    }
     
   } else{
     info.vcf <- tibble(variant_id = var_ind) %>%
@@ -268,6 +331,14 @@ for(i in 1:p){
                   rename('chr' = seqnames)) %>%
       bind_cols(.vcf@fixed %>% as_tibble()) %>%
       bind_cols(.vcf@info %>% as_tibble()) 
+    
+    if(debug_mode){
+      end <- Sys.time() 
+      message("Done Parsing Variant Info:") 
+      print(end - start)  
+      start <- end
+    }
+    
   }
   
   names(info.vcf) %<>% tolower()
@@ -277,15 +348,21 @@ for(i in 1:p){
   ## fix a few weird formatting things on the columns
   ## then add filepaths for variants
   
-  # message("fixing 'AsIs' INFO columns") ## debug
+  if(debug_mode){message("fixing 'AsIs' INFO columns")}
   
   info.vcf <- info.vcf %>%
     mutate(alt = sapply(alt, as.character)) %>%
     mutate_if(function(x){class(x)=="AsIs"}, as.character) 
   
-   # message("done parsing info") ## debug
+  if(debug_mode){
+    message("done parsing info")
+    end <- Sys.time()
+    message("Done Fixing Variant Info:")
+    print(end - start)
+    start <- end
+  }
+  
   ## genotypes have to be combined to go into the genotype table
-   
   if (length(geno_col_names) > 0){
     
     .geno_col <- geno_col_names[1]
@@ -294,8 +371,15 @@ for(i in 1:p){
       bind_cols(geno(.vcf)[[.geno_col]] %>% as_tibble()) %>%
       gather(sample, !!.geno_col, -variant_id, -group)
     
+    if(debug_mode){
+      end <- Sys.time()
+      message("Done Subsetting Genos:")
+      print(end - start)  
+      start <- end  
+    }
+    
     for(.geno_col in geno_col_names[-1]){
-      # message(.geno_col) ## debug
+      message(.geno_col)
       geno_col <- enquo(.geno_col)
       
       if (class(geno(.vcf)[[.geno_col]]) == "matrix"){
@@ -317,12 +401,19 @@ for(i in 1:p){
                  value) %>%
           mutate(Var3 = str_c(.geno_col, "_", Var3)) %>%
           spread(Var3, value)
-  
+        
         geno.vcf <- geno.vcf %>%
           left_join(tmp, by = c("variant_id", "sample"))
       }
     }
     names(geno.vcf) %<>% tolower()
+    
+    if(debug_mode){
+      end <- Sys.time()
+      message("Done Parsing Geno Fields:")
+      print(end - start)
+      start <- end
+    }
     
     if('GT' %in% geno_col_names){
       geno.vcf <- geno.vcf %>%
@@ -330,7 +421,12 @@ for(i in 1:p){
                gt = gt2snp(gt_raw))
     }
     
-    # message("done paring GENO") ## debug
+    if(debug_mode){
+      end <- Sys.time()
+      message("Done Converting GT to Numeric:")
+      print(end - start)
+      start <- end
+    }
     
     if(file_mode){
       ## add path to genos to info table
@@ -350,9 +446,14 @@ for(i in 1:p){
         )
         plan(sequential)
       } else{
-        tmp <- quietly(map2(geno.vcf$data, geno.vcf$group, 
-                            ~write_rds(as.data.frame(.x), str_c(geno_dir, "/", .y, ".rds"))
-        )
+        tmp <- quietly(
+          map2(geno.vcf$data, 
+               geno.vcf$group, 
+               function(.x, .y){
+                 write_rds(as.data.frame(.x), str_c(geno_dir, "/", .y, ".rds"))
+                 
+               }
+          )
         )
       }
     } else {
@@ -361,36 +462,70 @@ for(i in 1:p){
         select(-group) %>%
         arrange(variant_id, sample)
       con <- dbConnect(SQLite(), db_name)
-      db_insert_into(con = con, 
-                     table = "variant_geno", 
-                     geno.vcf) 
-      dbDisconnect(con)
+      DBI::dbWriteTable(
+        conn = con, 
+        name = "variant_geno", 
+        value = geno.vcf, 
+        append = TRUE) 
+      DBI::dbDisconnect(con)
     }
-    }
+  }
+  
+  if(debug_mode){
+    end <- Sys.time()
+    message("Done Writing Genotypes:")
+    print(end - start)
+    start <- end
+  }
   
   ## Write to database
-  con <- dbConnect(SQLite(), db_name, synchronous = NULL )
+  con <- dbConnect(SQLite(), db_name)
   if(exists('csq.vcf')){
-    db_insert_into(con = con, 
-                   table = "variant_impact", 
-                   csq.vcf) 
+    DBI::dbWriteTable(
+      conn = con, 
+      name = "variant_impact",
+      value = csq.vcf, 
+      append = TRUE) 
   }
-  db_insert_into(con = con,
-                 table = "variant_info",
-                 info.vcf)
+  DBI::dbWriteTable(
+    conn = con,
+    name = "variant_info",
+    value = info.vcf, 
+    append = TRUE)
   dbDisconnect(con)
   
-  # message("Done writing/insering variants") ## debug
-  rm(.vcf, info.vcf)
+  if(debug_mode){
+  end <- Sys.time() 
+  message("Done Inserting Annotations in DB:") 
+  print(end - start)
+  start <- end
+  }
+  
+  if(debug_mode){message("Done writing/insering variants")}
+  
+  rm(.vcf, info.vcf, geno.vcf)
   if(exists('csq.vcf')){
-    rm(csq.vcf) 
+    rm(csq.vcf)
   }
   gc(verbose = FALSE)
+  
+  if(debug_mode){
+    end <- Sys.time() 
+    message("Done Collecting Garbage:")
+    print(end - start)
+    start <- end  
+  }
+  
+  chunk_start <- i
+  index_start <- last(var_ind)
+  save(index_start, chunk_start, csq_exists, csq_cols, exonic_impacts, geno_col_names, gt2snp, header, keep_geno_col, ranges_name, vcf_header, vcf_name, 
+       file = paste0(prefix, ".progress.RData"))
 }
+
 ## end loop
 message("######\nDone inserting variants\n#####")
 date()
 closeAllConnections()
 
 ### Make geno dir read-only
-if(file_mode){Sys.chmod(geno_dir, mode = "555")}
+# if(file_mode){Sys.chmod(geno_dir, mode = "555")}

--- a/pipeline/02-build-db.R
+++ b/pipeline/02-build-db.R
@@ -252,7 +252,7 @@ for(i in 1:p){
                   as_tibble() %>% 
                   select(seqnames, start, end) %>% 
                   rename('chr' = seqnames)) %>%
-      bind_cols(.vcf@fixed %>% as_tibble(), ) %>%
+      bind_cols(.vcf@fixed %>% as_tibble()) %>%
       bind_cols(.vcf@info %>% as_tibble()) 
   }
   
@@ -262,11 +262,16 @@ for(i in 1:p){
   
   ## fix a few weird formatting things on the columns
   ## then add filepaths for variants
+  
+  message("fixing 'AsIs' INFO columns") ## debug
+  
   info.vcf <- info.vcf %>%
     mutate(alt = sapply(alt, as.character)) %>%
     mutate_if(function(x){class(x)=="AsIs"}, as.character) 
   
+   message("done parsing info") ## debug
   ## genotypes have to be combined to go into the genotype table
+   
   if (length(geno_col_names) > 0){
     
     .geno_col <- geno_col_names[1]
@@ -276,6 +281,7 @@ for(i in 1:p){
       gather(sample, !!.geno_col, -variant_id, -group)
     
     for(.geno_col in geno_col_names[-1]){
+      message(.geno_col) ## debug
       geno_col <- enquo(.geno_col)
       geno.vcf <- geno.vcf %>%
         bind_cols(
@@ -293,6 +299,7 @@ for(i in 1:p){
                gt = gt2snp(gt_raw))
     }
     
+    message("done paring GENO") ## debug
     
     if(file_mode){
       ## add path to genos to info table
@@ -339,6 +346,8 @@ for(i in 1:p){
                  table = "variant_info",
                  info.vcf)
   dbDisconnect(con)
+  
+  message("Done writing/insering variants") ## debug
 }
 ## end loop
 message("######\nDone inserting variants\n#####")

--- a/pipeline/03-index-db.R
+++ b/pipeline/03-index-db.R
@@ -86,7 +86,7 @@ if ('variant_impact' %in% DBI::dbListTables(con)){
   var_imp <- tbl(con, 'variant_impact')
   
   gene_dat <- var_imp %>% 
-    select(symbol, symbol_source, gene, source, feature, canonical, ensp, ccds, motif_name, feature_type) %>% 
+    select(c('symbol', 'symbol_source', 'gene', 'source', 'feature', 'canonical', 'ensp', 'ccds', 'motif_name', 'feature_type')) %>% 
     collect() %>% 
     distinct() 
   

--- a/pipeline/03-index-db.R
+++ b/pipeline/03-index-db.R
@@ -86,7 +86,7 @@ if ('variant_impact' %in% DBI::dbListTables(con)){
   var_imp <- tbl(con, 'variant_impact')
   
   gene_dat <- var_imp %>% 
-    select(c('symbol', 'symbol_source', 'gene', 'source', 'feature', 'canonical', 'ensp', 'ccds', 'motif_name', 'feature_type')) %>% 
+    select(any_of(c('symbol', 'symbol_source', 'gene', 'source', 'feature', 'canonical', 'ensp', 'ccds', 'motif_name', 'feature_type'))) %>% 
     collect() %>% 
     distinct() 
   

--- a/pipeline/03-index-db.R
+++ b/pipeline/03-index-db.R
@@ -22,12 +22,12 @@ if(!exists("db_name")){
   stop("A database must be passed with the `--db` argument")
 }
 
-require(VariantAnnotation)
-require(dbplyr)
-require(tidyverse)
-require(magrittr)
-require(DBI)
-require(RSQLite)
+suppressPackageStartupMessages(require(VariantAnnotation))
+suppressPackageStartupMessages(require(dbplyr))
+suppressPackageStartupMessages(require(tidyverse))
+suppressPackageStartupMessages(require(magrittr))
+suppressPackageStartupMessages(require(DBI))
+suppressPackageStartupMessages(require(RSQLite))
 
 
 ## build indicies

--- a/pipeline/03-index-db.R
+++ b/pipeline/03-index-db.R
@@ -26,7 +26,9 @@ require(VariantAnnotation)
 require(dbplyr)
 require(tidyverse)
 require(magrittr)
+require(DBI)
 require(RSQLite)
+
 
 ## build indicies
 message("######\nBUILDING INDICIES\n######")
@@ -92,11 +94,10 @@ if ('variant_impact' %in% DBI::dbListTables(con)){
   
   gene_dat[gene_dat == ""] <- NA
   
-  db_insert_into(con = con, 
-                 table = "gene_map", 
-                 gene_dat)
-  
-  dbDisconnect(con)
+  DBI::dbWriteTable(
+    conn = con,
+    name = "gene_map", 
+    value = gene_dat)
 }
-
+dbDisconnect(con)
 message("######\nVCFdb creation ended on\n", date(), "\n######")


### PR DESCRIPTION
Checkpoints consist of a handful of R objects  saved in `[prefix].RData`. As long as a crash or interruption does not occur while tables are being written to the database (a very short amount of time, particularly for file-GT databases) progress should be able to be resumed where it left off with relatively little wasted time. 

Multi-value GT fields are fairly common, but are handled inefficiently by readVcf. Here is an option to include them, but it is quite slow if there are hundreds or more samples in the VCF. In that case, it is probably faster to recode those GT fields as separate fields. The default remains to exclude them. 